### PR TITLE
add code to set browser cookies to postman request

### DIFF
--- a/extension/js/background_page.js
+++ b/extension/js/background_page.js
@@ -265,6 +265,21 @@ function setCookiesFromHeader(cookieHeader, url) {
 	}
 }
 
+//Setting browser cookies for postman's request url
+function setExistingBrowserCookiesForUrl(url){
+    return new Promise(function(resolve, reject){
+        chrome.cookies.getAll({url:url}, function(cookies) {
+            for (var i = 0; i < cookies.length; i++) {
+                chrome.cookies.set({
+                    url: url,
+                    name: cookies[i].name,
+                    value: cookies[i].value
+                });
+            }
+            resolve()
+        });
+    });
+}
 
 // the workhorse function - sends the XHR on behalf of postman
 function sendXhrRequest(postmanMessage) {
@@ -527,7 +542,9 @@ function onExternalMessage(request, sender, sendResponse) {
       var type = request.postmanMessage.type;
 
       if (type === "xhrRequest") {
-      	sendXhrRequest(request.postmanMessage);
+          var currentRequest = request.postmanMessage.request;
+          setExistingBrowserCookiesForUrl(currentRequest.url)
+              .then(function(){sendXhrRequest(request.postmanMessage)});
       }
       else if (type === "detectExtension") {
         sendResponse({"result": true});	


### PR DESCRIPTION
chrome suppose to send the existing cookies for requested url by postman app by default if browser has any. somehow the behavior is different when make request from postman postman-chrome-interceptor which requested by postman app. my fix always read the cookie from browser for the requested url by postman and setting again before make the request. that way always all the cookies for particular url will be send with that request